### PR TITLE
Add p5 update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,27 @@ $ p5 s
 
 Now edit your sketch.js and go to `localhost:5555/PROJECT_NAME`, then p5-manager will do the rest. (Notice: you should run `p5 server` in a collection directory, instead of a project directory)
 
+## Update libraries
+To update p5 libraries to the latest version:
+
+```bash
+$ cd my_collection
+$ p5 update
+# or...
+$ p5 u
+```
+By running this, p5-manager will check the latest release tag of p5.js on github, and download `p5.js`, `p5.dom.js` and `p5.sound.js` to the `libraries` folder in your collection.
+
+```bash
+#The latest p5.js release is version 0.5.3
+#   downloading : p5.js...
+#   downloading : p5.dom.js...
+#   downloading : p5.sound.js...
+#   updated : p5.dom.js
+#   updated : p5.sound.js
+#   updated : p5.js
+```
+
 ## Static mode v.s GUI mode
 There are two ways to get access to your sketch. One is via public path, ex: `localhost:5555/demo1/index.html`. The other way is GUI mode, just go to: `localhost:5555` to have fun with our GUI panel.
 
@@ -69,6 +90,8 @@ $ p5 g my_project_es6 --es6
 
 ### .p5rc
 The main purpose of `.p5rc` is to track projects in the collection. Once you generate a project with command `p5 generate`, it will be automatically. added to `.p5rc`. Projects listed in the `.p5rc` file would be servered in the GUI mode.
+
+Currently, if you create a project without using `p5 generate`, you'll have to append the project name into `.p5rc` on your own, to add it to stage.
 
 ## About this project
 I'm a graphic design student who use p5.js a lot so I need something to help me develop, manage or demo my p5.js projects more efficiently. That's why p5-manager was made.

--- a/bin/p5-manager.js
+++ b/bin/p5-manager.js
@@ -29,4 +29,12 @@ program
 		server.run(5555);
 	});
 
+program
+  .command('update')
+  .alias('u')
+  .description('Update libraries to latest version')
+  .action(function(req, res) {
+    generator.update();
+  })
+
 program.parse(process.argv);

--- a/generator/generator.js
+++ b/generator/generator.js
@@ -1,6 +1,7 @@
-var mkdirp = require('mkdirp');
 var fs = require('fs');
 var path = require('path');
+var request = require('request');
+var download = require('download');
 
 var templates = {
 	sketchjs: loadFile('templates/sketch.js'),
@@ -42,7 +43,38 @@ var generator = {
 			}
 			write(project + '/index.html', templates.indexhtml);
 		});
-	}
+	},
+  update: function() {
+    var option = {
+      url: 'https://api.github.com/repos/processing/p5.js/releases/latest',
+      headers: {
+        'User-Agent': 'chiunhau/p5-manager'
+      }
+    }
+
+    request(option, function(error, res, body) {
+      // get latest release tag
+      var obj = JSON.parse(body);
+      console.log('The latest p5.js release is version ' + obj.tag_name);
+
+      download(libPath(obj.tag_name, 'p5.js'), 'libraries').then(() => {
+        console.log('   \033[36mupdated\033[0m : '  + 'p5.js');
+      });
+      download(libPath(obj.tag_name, 'p5.dom.js'), 'libraries').then(() => {
+        console.log('   \033[36mupdated\033[0m : '  + 'p5.dom.js');
+      });
+      download(libPath(obj.tag_name, 'p5.sound.js'), 'libraries').then(() => {
+        console.log('   \033[36mupdated\033[0m : '  + 'p5.sound.js');
+      });
+    });
+  }
+}
+
+function libPath(tag, filename) {
+  var fullpath = 'https://github.com/processing/p5.js/releases/download/' + tag + '/' + filename;
+  console.log('   \033[36mdownloading\033[0m : '  + filename + '...');
+
+  return fullpath
 }
 
 // the following code are taken from https://github.com/expressjs/generator
@@ -57,7 +89,7 @@ function write(path, str, mode) {
 }
 
 function mkdir(path, fn) {
-  mkdirp(path, 0755, function(err){
+  fs.mkdir(path, 0755, function(err){
     if (err) throw err;
     console.log('   \033[36mcreate\033[0m : ' + path);
     fn && fn();

--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
     "chokidar": "^1.6.0",
     "commander": "^2.9.0",
     "debug": "~2.2.0",
+    "download": "^5.0.2",
     "express": "~4.13.4",
-    "mkdirp": "^0.5.1",
     "morgan": "~1.7.0",
     "pug": "^2.0.0-beta4",
+    "request": "^2.74.0",
     "serve-favicon": "~2.3.0"
   }
 }


### PR DESCRIPTION
- now able to use `p5 update` to update p5 libraries to latest release
- new dependencies: **request**, **download**
- remove dependencies: **mkdirp**
