### PR TITLE
Removes mixed space and tab. Includes the project name to the HTML title.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# HTML
+[*.html]
+indent_style = tab
+indent_size = 2
+
+# HTML
+[*.js]
+indent_style = tab
+indent_size = 2

--- a/generator/generator.js
+++ b/generator/generator.js
@@ -29,6 +29,9 @@ var generator = {
 	},
 	project: function(project, opt) {
 
+		templates.indexhtml = templates.indexhtml.replace('{{project-title}}', project);
+		templates.indexhtmlb = templates.indexhtmlb.replace('{{project-title}}', project);
+
 		mkdir(project, function() {
 			if(opt.bundle) {
 				createLibraries(project)

--- a/generator/templates/index-bundle.html
+++ b/generator/templates/index-bundle.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 	<meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 
-	<title>New p5 Project</title>
+	<title>{{project-title}}</title>
 
 	<script src="libraries/p5.js"></script>
 	<script src="libraries/p5.dom.js"></script>
@@ -14,13 +14,13 @@
 
 	<style>
 		body {
-		  margin:0;
-      padding:0;
-      overflow: hidden;
-    }
-    canvas {
-      margin:auto;
-    }
+			margin:0;
+			padding:0;
+			overflow: hidden;
+		}
+		canvas {
+			margin:auto;
+		}
 	</style>
 </head>
 <body>

--- a/generator/templates/index.html
+++ b/generator/templates/index.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 	<meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 
-	<title>New p5 Project</title>
+	<title>{{project-title}}</title>
 
 	<script src="../libraries/p5.js"></script>
 	<script src="../libraries/p5.dom.js"></script>
@@ -14,13 +14,13 @@
 
 	<style>
 		body {
-		  margin:0;
-      padding:0;
-      overflow: hidden;
-    }
-    canvas {
-      margin:auto;
-    }
+			margin:0;
+			padding:0;
+			overflow: hidden;
+		}
+		canvas {
+			margin:auto;
+		}
 	</style>
 </head>
 <body>


### PR DESCRIPTION
I love using this p5 manager. 2 things bother me, though. The broken indentation on the HTML file and the project name not being in the HTML title. I’ve made this quick fixing and implementation. Feel free to ignore them if you think it’s not relevant.

Thanks!
