### PR TITLE
Support for creating (bundle) project files in the current working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ p5 generate --bundle PROJECT_NAME
 p5 g -b PROJECT_NAME
 ```
 
+or to generate in the current folder, do this:
+
+```bash
+p5 generate --bundle .
+# or...
+p5 g -b .
+```
+
 Which will do something like this:
 
 ```bash


### PR DESCRIPTION
Implemented (and documented) support for creating project files in the current working directory.

To do so, you have to pass "." as a project name to the `p5 g -b` command like this: `p5 g -b .`. This takes the name of the current working directory and puts it in the title of the generated html page, all while putting the generated files in the current directory.